### PR TITLE
refactor(ui,store): replace per-field setters with `updateTaskForm`; refresh shared types

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,20 +1,5 @@
-export type Task = {
-  id: string; // use uuid for stability across imports
-  name: string;
-  description?: string;
-  startTime: string; // "HH:MM"
-  endTime: string; // "HH:MM"
-  duration: number; // minutes
-  color: ColorName;
-};
-
-export type DayExport = { dateKey: string; items: Task[] };
-
-export type PlannerExport = {
-  exportedAt: string;
-  planner: { startTime: string; endTime: string; interval: number };
-  days: DayExport[];
-};
+/** "HH:MM" 24-hour time string (e.g., "08:00", "23:30"). */
+export type TimeHHMM = string;
 
 export type ColorName =
   | 'blue'
@@ -25,3 +10,58 @@ export type ColorName =
   | 'orange'
   | 'cyan'
   | 'neutral';
+
+export type Task = {
+  id: string; 
+  name: string;
+  description?: string;
+  startTime: TimeHHMM; 
+  endTime: TimeHHMM; 
+  duration: number; 
+  color: ColorName;
+};
+
+export type DayExport = { dateKey: string; items: Task[] };
+
+export type PlannerConfig = {
+  startTime: TimeHHMM;
+  endTime: TimeHHMM;
+  interval: number; 
+};
+
+export type PlannerExport = {
+  exportedAt: string; 
+  planner: PlannerConfig;
+  days: DayExport[];
+};
+
+export type PendingTask = {
+  task: Task;
+  dateKey: string;
+};
+
+export type ScheduleDisplayRow = {
+  time: TimeHHMM;
+  task: Task | null;
+  isTaskStart: boolean;
+  rowSpan: number;
+};
+
+export type TaskFormState = {
+  taskName: string;
+  taskDesc: string;
+  taskStartTime: TimeHHMM;
+  taskDuration: string;
+  selectedColor: ColorName;
+  nameError: boolean;
+};
+
+export type ShareRequest = {
+  dateKey: string;
+  items: Task[];
+  planner: PlannerConfig;
+};
+
+export type ShareResponse = {
+  url: string;
+};


### PR DESCRIPTION
- Consolidate task form updates into a single `updateTaskForm(patch)` API
  replacing:
    - `setTaskName(...)`
    - `setTaskDesc(...)`
    - `setSelectedColor(...)`
    - (and similar per-field setters)
- Update `page.tsx` to use a unified `taskForm` state + `updateTaskForm(...)`
  for all inputs (name, desc, startTime, duration, color, error flag).
- Strengthen shared types in `lib/types.ts`:
  - add `TimeHHMM`, `PlannerConfig`, `TaskFormState`, `ScheduleDisplayRow`,
    `PendingTask`, and (optional) `ShareRequest`/`ShareResponse`
  - keep existing `Task`, `DayExport`, `PlannerExport`, `ColorName` intact

Why:
- Fewer renders and cleaner API by batching related field changes
- Easier to extend the form without adding new setter methods
- Clearer type contracts across UI and store

**BREAKING CHANGE**: per-field task form setters are removed.
Old:
```ts
  store.setTaskName('Math');
  store.setTaskDesc('Study');
  store.setSelectedColor('blue');
```

New:
```ts
  store.updateTaskForm({
    taskName: 'Math',
    taskDesc: 'Study',
    selectedColor: 'blue',
  });
```